### PR TITLE
Added method removes ignored lines

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -38,8 +38,10 @@ func checkWordByDictionary(word string, dictWords []*regexp.Regexp) bool {
 
 // Check checks misspells in a chunk of text
 func Check(chunk *reader.Chunk, cfg *config.Config) error {
+	text := RemoveIgnoredLines(chunk.Text)
+
 	resp, err := http.PostForm(serviceURL, url.Values{
-		"text":    {chunk.Text},
+		"text":    {text},
 		"lang":    {cfg.Lang},
 		"format":  {cfg.Format},
 		"options": {strconv.Itoa(int(cfg.Options))},

--- a/checker/remove.go
+++ b/checker/remove.go
@@ -1,0 +1,27 @@
+package checker
+
+import (
+	"math"
+	"strings"
+)
+
+// IgnoreComment it's comment name
+const IgnoreComment = "yaspell-disable-next-line"
+
+// RemoveIgnoredLines removes comment and next line
+func RemoveIgnoredLines(str string) string {
+	ignoreLine := -math.MaxInt8
+	temp := strings.Split(str, "\n")
+	text := make([]string, 0)
+
+	for idx, item := range temp {
+		if strings.Contains(item, IgnoreComment) {
+			ignoreLine = idx
+		} else if ignoreLine+1 != idx {
+			text = append(text, item)
+			ignoreLine = -math.MaxInt8
+		}
+	}
+
+	return strings.Join(text, "\n")
+}

--- a/checker/remove_test.go
+++ b/checker/remove_test.go
@@ -1,0 +1,17 @@
+package checker_test
+
+import (
+	"github.com/vodkabears/yaspell/checker"
+	"testing"
+)
+
+func TestRemoveIgnoredLines(t *testing.T) {
+	str := "string_1\nstring_2\n// yaspell-disable-next-line\nstring_3\nstring_4"
+	expected := "string_1\nstring_2\nstring_4"
+
+	result := checker.RemoveIgnoredLines(str)
+
+	if result != expected {
+		t.Errorf("Expected to remove ignore lines.\nResult:\n%s \n\nExpected:\n%s", result, expected)
+	}
+}


### PR DESCRIPTION
Проблема:
Столкнулись с тем, что есть некоторые строки, которые спелчекер отказывается нормально прожевывать, например `Автоматичес‐\u000Dкие`

Решение:
Решили добавить функционал, что бы как `eslint-disable-next-line` можно было добавить комментарий и блокировать следующую строчку